### PR TITLE
Add nix development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1671489820,
+        "narHash": "sha256-qoei5HDJ8psd1YUPD7DhbHdhLIT9L2nadscp4Qk37uk=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "5aa3a8039c68b4bf869327446590f4cdf90bb634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643381941,
+        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1673226411,
+        "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Development environment for FRC 2023";
+  inputs = {
+    devshell.url = "github:numtide/devshell";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+  outputs = {
+    devshell,
+    nixpkgs,
+    ...
+  }: let
+    genSystems = nixpkgs.lib.genAttrs ["x86_64-linux"];
+  in {
+    devShells = genSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      createAlias = newName: pkg: bin:
+        pkgs.symlinkJoin {
+          name = newName;
+          paths = [(pkgs.writeShellScriptBin "${newName}" "${pkgs.${pkg}}/bin/${bin} $@") pkgs.${pkg}];
+          buildInputs = [pkgs.makeWrapper];
+          postBuild = "wrapProgram $out/bin/${newName} --prefix PATH : $out/bin";
+        };
+      createAliasSame = newName: pkg: createAlias newName pkg pkg;
+
+      jdtlsAlias = createAliasSame "jdtls" "jdt-language-server";
+    in {
+      default = devshell.legacyPackages.${system}.mkShell {
+        packages = with pkgs; [
+          jdk11
+          jdt-language-server
+          jdtlsAlias
+        ];
+        name = "FRC 2023 robot dev shell";
+        commands = [
+          {
+            help = "The Java Programming Language";
+            name = "java";
+						package = pkgs.jdk11;
+          }
+          {
+            help = "The build system used to build everything";
+            package = pkgs.gradle;
+          }
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
This pull request adds a nix development shell built with devshell, this is helpful if you want to quickly load up into a shell with tools needed for development. I know I might be the only one to use this, but it would be cool, also I can't really keep this separate from this repo.

example usage:
`nix develop`

background info:
Nix is a fully functional declarative package manager that allows for declarative development environments. Nix works on macOS, and Linux, and also has a linux distro build around it.