### PR TITLE
Reduced repetition in drivetrain code

### DIFF
--- a/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
@@ -137,18 +137,27 @@ public class DriveTrainSubsystem extends SubsystemBase {
     return zRotation;
   }
 
+  private RelativeEncoder[] getAllEncoders() {
+    return new RelativeEncoder[](
+      frontLeftEncoder, 
+      frontRightEncoder, 
+      rearLeftEncoder, 
+      rearRightEncoder
+    );
+  }
+
   public void resetEncoders() {
-      frontLeftEncoder.setPosition(0);
-      frontRightEncoder.setPosition(0);
-      rearLeftEncoder.setPosition(0);
-      rearRightEncoder.setPosition(0);
+    for (RelativeEncoder encoder : getAllEncoders())
+    {
+      encoder.setPosition(0);
+    }
   }
 
   public void setAllEncoders(double position) {
-    frontLeftEncoder.setPosition(position);
-    frontRightEncoder.setPosition(position);
-    rearLeftEncoder.setPosition(position);
-    rearRightEncoder.setPosition(position);
+    for (RelativeEncoder encoder : getAllEncoders())
+    {
+      encoder.setPosition(position);
+    }
   }
 
   public void resetOdometry(Pose2d pose) {

--- a/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
@@ -50,6 +50,8 @@ public class DriveTrainSubsystem extends SubsystemBase {
   private final DifferentialDrive tankDrive;
   private final DifferentialDriveOdometry odometry;
 
+  private final RelativeEncoder[] encoders;
+
 
   /** Creates a new ExampleSubsystem. */
   public DriveTrainSubsystem() {
@@ -76,6 +78,13 @@ public class DriveTrainSubsystem extends SubsystemBase {
     this.rearLeftMotor.setInverted(true);
 
     this.odometry = new DifferentialDriveOdometry(new Rotation2d(Gyro.getGyroAngle()), 0, 0);
+
+    this.encoders = new RelativeEncoder[]{
+      frontLeftEncoder, 
+      frontRightEncoder, 
+      rearLeftEncoder, 
+      rearRightEncoder
+    };
 
     this.tankDrive = new DifferentialDrive(leftMotorGroup, rightMotorGroup);
     // m_dDrive.setSafetyEnabled(false);
@@ -137,24 +146,15 @@ public class DriveTrainSubsystem extends SubsystemBase {
     return zRotation;
   }
 
-  private RelativeEncoder[] getAllEncoders() {
-    return new RelativeEncoder[](
-      frontLeftEncoder, 
-      frontRightEncoder, 
-      rearLeftEncoder, 
-      rearRightEncoder
-    );
-  }
-
   public void resetEncoders() {
-    for (RelativeEncoder encoder : getAllEncoders())
+    for (RelativeEncoder encoder : encoders)
     {
       encoder.setPosition(0);
     }
   }
 
   public void setAllEncoders(double position) {
-    for (RelativeEncoder encoder : getAllEncoders())
+    for (RelativeEncoder encoder : encoders)
     {
       encoder.setPosition(position);
     }


### PR DESCRIPTION
I made a method that returns all of the encoders in the drivetrain, and changed `resetEncoders` and `setAllEncoders` to use this method and a foreach loop instead of the same code 4 times.